### PR TITLE
fix(ci): resolve Codecov PR comments and main branch coverage issues

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,18 +4,31 @@ coverage:
             default:
                 target: 30%
                 threshold: 0%
+                base: auto
+                if_not_found: success
+                if_ci_failed: error
+                only_pulls: false
         patch:
             default:
                 target: auto
                 threshold: 1%
+                base: auto
+                if_not_found: success
+                only_pulls: false
 
 comment:
     layout: "reach,diff,flags,files,footer"
     behavior: default
     require_changes: false
     require_base: false
-    require_head: true
-    after_n_builds: 1
-    
+    require_head: false
+
 github_checks:
     annotations: false
+
+codecov:
+    require_ci_to_pass: false
+    notify:
+        wait_for_ci: false
+    branch: main
+    strict_yaml_branch: main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+      actions: read
+      statuses: write
     steps:
       - uses: actions/checkout@v4
 
@@ -92,6 +98,11 @@ jobs:
           verbose: true
           name: rust-coverage
           flags: unittests
+          override_branch: ${{ github.head_ref || github.ref_name }}
+          override_commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          override_pr: ${{ github.event.pull_request.number }}
+          override_build: ${{ github.run_id }}
+          override_build_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Add missing permissions to coverage job for PR write access
- Add explicit metadata overrides for branch, commit, and PR detection
- Remove after_n_builds constraint that blocked immediate comments
- Set only_pulls: false to enable main branch coverage tracking
- Configure if_not_found: success for missing base comparisons
- Set require_head: false to allow main branch uploads
- Add branch: main configuration for proper baseline tracking

These changes ensure:
1. PR comments from Codecov appear consistently
2. Main branch coverage is properly tracked as baseline
3. Coverage diffs between PR and main are accurately calculated