### PR TITLE
fix: improve codecov coverage report generation and upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,14 +61,15 @@ jobs:
       - name: Generate code coverage
         run: |
           # Avoid enabling the optional `python` feature to prevent PyO3 linking on CI
-          cargo tarpaulin --verbose --workspace --timeout 120 --out xml
+          cargo tarpaulin --engine llvm --no-dead-code --no-fail-fast --all-features --workspace --timeout 120 -o xml --output-dir ./cov-reports --skip-clean
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
-          path: cobertura.xml
+          path: ./cov-reports
           retention-days: 1
+          if-no-files-found: error
 
       - name: Clippy
         run: cargo make clippy-ci --locked
@@ -94,10 +95,13 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           name: coverage-report
+          path: ./cov-reports
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./
+          directory: ./cov-reports
           fail_ci_if_error: true
+          files: '*.xml'
+          verbose: true


### PR DESCRIPTION
- Use tarpaulin with llvm engine and proper output directory configuration
- Generate coverage reports in ./cov-reports directory (same as hudi-rs)
- Fix artifact upload/download paths to use consistent directory structure
- Add verbose output and file pattern for codecov action
- Add if-no-files-found error check to catch missing reports early

This should resolve the codecov upload issues and ensure coverage reports are properly generated and visible on codecov.io